### PR TITLE
FIX: Reduktion von Groebner-Basen nun richtig implementieren.

### DIFF
--- a/ak_18/blatt05.ipynb
+++ b/ak_18/blatt05.ipynb
@@ -67,22 +67,26 @@
     "    # Leitkoeffizienten normieren\n",
     "    G = list(map(lambda p: p / p.LC, G))\n",
     "    \n",
-    "    def is_div_LT(gg):\n",
-    "        p, Gt = gg\n",
+    "    def is_div_LT(p, Gt):\n",
     "        LT = lambda p: p.leading_monom()\n",
-    "        return not any(LT(p).div(LT(f))[1] == 0 for f in Gt)\n",
+    "        return any(LT(p).div(LT(f))[1] == 0 for f in Gt)\n",
     "    \n",
-    "    def div_rem(gg):\n",
-    "        p, Gt = gg\n",
+    "    def div_rem(p, Gt):\n",
     "        return p.div(Gt)[1]\n",
     "    \n",
     "    # Polynome deren Leitterme durch Leitterme anderer\n",
-    "    # Polynome teilbar sind herausfiltern.\n",
-    "    gg = filter(is_div_LT, zip(G, [G[:i-1] + G[i:] for i in range(1, len(G)+1)]))\n",
-    "    \n",
+    "    # Polynome teilbar sind herausfiltern\n",
+    "    i = 0\n",
+    "    while i < len(G):\n",
+    "        if is_div_LT(G[i], G[:i] + G[i+1:]): del G[i]\n",
+    "        else: i += 1\n",
+    "\n",
     "    # Jedes Polynom mit seinem Rest beim Dividieren durch den\n",
     "    # Rest der GB ersetzen. siehe Bew. von Thm 4.22\n",
-    "    return list(map(div_rem, gg))"
+    "    for i in range(len(G)):\n",
+    "        G[i] = div_rem(G[i], G[:i] + G[i+1:])\n",
+    "\n",
+    "    return G"
    ]
   },
   {
@@ -387,6 +391,38 @@
    ],
    "source": [
     "reduce_groebner(G)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "P, (x, y) = xring('x,y', QQ, lex)\n",
+    "G = [x**2 + 2*y**2 - 2, x**2 + x*y + y**2 - 2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[x**2 + 2*y**2 - 2, x*y - y**2, y**3 - 2/3*y]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gt.groebner(G, P)"
    ]
   }
  ],


### PR DESCRIPTION
Der bisherige Reduktion-Schritt lief insofern falsch ab, als dass
bei einer Groebner-Basis (unreduziert), die zwei Polynome mit bis auf
Vorfaktor gleichem Leitkoeffizienten enthaelt, dort BEIDE Polynome
geloescht werden, statt nur einem. Als Bsp zum Ausprobieren (von
Blatt 09 Aufgabe 27): < x**2+2*y**2-2, x**2+x*y+y**2-2 >.